### PR TITLE
Optional autocomplete in CLI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,14 @@ Note: the ``containers`` subcommand requires ``docker`` to already be installed
 on your machine. Please see the `docker installation instructions <http://docs.docker.com/index.html>`_ for platform
 specific information.
 
+autocomplete
+^^^^^^^^^^^^
+
+To enable tab autocomplete, please install `argcomplete <https://github.com/kislyuk/argcomplete>`_ using ``pip install autocomplete``.
+Then adding the line ``eval "$(register-python-argcomplete dataduct)"`` to enable autocomplete for bash.
+See the argcomplete documentation for enable autocomplete for zsh.
+
+
 Setup
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Installation
 
 To install this package, execute::
 
-    sudo pip install courseraresearchexports
+    pip install courseraresearchexports
 
 `pip <https://pip.pypa.io/en/latest/index.html>`_ is a python package manager.
 If you do not have ``pip`` installed on your machine, please follow the
@@ -28,8 +28,7 @@ autocomplete
 ^^^^^^^^^^^^
 
 To enable tab autocomplete, please install `argcomplete <https://github.com/kislyuk/argcomplete>`_ using ``pip install autocomplete``.
-Then adding the line ``eval "$(register-python-argcomplete dataduct)"`` to enable autocomplete for bash.
-See the argcomplete documentation for enable autocomplete for zsh.
+See the argcomplete documentation for enable global autocomplete for your shell.
 
 
 Setup

--- a/README.rst
+++ b/README.rst
@@ -27,9 +27,11 @@ specific information.
 autocomplete
 ^^^^^^^^^^^^
 
-To enable tab autocomplete, please install `argcomplete <https://github.com/kislyuk/argcomplete>`_ using ``pip install autocomplete``.
-See the argcomplete documentation for enable global autocomplete for your shell.
+To enable tab autocomplete, please install `argcomplete <https://github.com/kislyuk/argcomplete>`_ using
+``pip install autocomplete`` and execute ``activate-global-python-argcomplete``. Open a new shell and
+press tab for autocomplete functionality.
 
+See the argcomplete documentation for more details.
 
 Setup
 -----

--- a/courseraresearchexports/main.py
+++ b/courseraresearchexports/main.py
@@ -21,6 +21,7 @@ Coursera's tools for interacting with research data exports.
 You may install it from source, or via pip.
 """
 
+import argcomplete
 import argparse
 import logging
 import sys
@@ -70,11 +71,9 @@ def main():
     """
     logging.captureWarnings(True)
     parser = build_parser()
-    try:
-        import argcomplete
-        argcomplete.autocomplete(parser)
-    except ImportError:
-        pass
+
+    argcomplete.autocomplete(parser)
+
     args = parser.parse_args()
     # Configure logging
     args.setup_logging(args)

--- a/courseraresearchexports/main.py
+++ b/courseraresearchexports/main.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# PYTHON_ARGCOMPLETE_OK
 
 # Copyright 2016 Coursera
 #
@@ -68,7 +69,13 @@ def main():
     Boots up the command line tool
     """
     logging.captureWarnings(True)
-    args = build_parser().parse_args()
+    parser = build_parser()
+    try:
+        import argcomplete
+        argcomplete.autocomplete(parser)
+    except ImportError:
+        pass
+    args = parser.parse_args()
     # Configure logging
     args.setup_logging(args)
     # Dispatch into the appropriate subcommand function.

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
               'courseraresearchexports.containers',
               'courseraresearchexports.models'],
     install_requires=[
+        'argcomplete>=1.4.1',
         'courseraoauth2client>=0.0.1',
         'requests>=2.7.0',
         'docker-py>=1.2.3',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 setup(
     name='courseraresearchexports',
-    version='0.0.2',
+    version='0.0.3',
     description='Command line tool for convenient access to '
     'Coursera Research Data Exports.',
     long_description=readme(),


### PR DESCRIPTION
PTAL @tlee-coursera for optional autocomplete, I'll publish the new version after merging.

Also in the instruction, got rid of the `sudo`. I think we want to add instructions for maybe running this in a virtualenv, and using `sudo` should be a last resort.

Refers to #8 issue.