### PR TITLE
Throw error if no clickstream link is available

### DIFF
--- a/courseraresearchexports/commands/jobs.py
+++ b/courseraresearchexports/commands/jobs.py
@@ -53,7 +53,7 @@ def request_clickstream(args):
                  .format(id=export_request_with_metadata.id))
     logging.debug('Request created with json body:\n{json}'
                   .format(json=json.dumps(
-                        export_request_with_metadata.to_json(), indent=2)))
+                      export_request_with_metadata.to_json(), indent=2)))
 
 
 def request_tables(args):
@@ -77,7 +77,7 @@ def request_tables(args):
                  .format(id=export_request_with_metadata.id))
     logging.debug('Request created with json body:\n{json}'
                   .format(json=json.dumps(
-                        export_request_with_metadata.to_json(), indent=2)))
+                      export_request_with_metadata.to_json(), indent=2)))
 
 
 def get(args):

--- a/courseraresearchexports/models/utils.py
+++ b/courseraresearchexports/models/utils.py
@@ -43,8 +43,8 @@ def requests_response_to_model(response_transformer):
                 logging.error(
                     'Request to {url} with body:\n\t{body}\nreceived response'
                     ':\n\t{text}\n'
-                    'Please contact data-support@coursera.org or #data-exports '
-                    'on Slack for assistance'
+                    'Please contact data-support@coursera.org or #data-exports'
+                    ' on Slack for assistance'
                     .format(url=response.url,
                             text=response.text,
                             body=(response.request and response.request.body)))

--- a/courseraresearchexports/models/utils.py
+++ b/courseraresearchexports/models/utils.py
@@ -42,8 +42,9 @@ def requests_response_to_model(response_transformer):
             except requests.exceptions.HTTPError:
                 logging.error(
                     'Request to {url} with body:\n\t{body}\nreceived response'
-                    ':\n\t{text}\nPlease check request or contact '
-                    'data-support@coursera.org if this error persists.'
+                    ':\n\t{text}\n'
+                    'Please contact data-support@coursera.org or #data-exports '
+                    'on Slack for assistance'
                     .format(url=response.url,
                             text=response.text,
                             body=(response.request and response.request.body)))

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 setup(
     name='courseraresearchexports',
-    version='0.0.17',
+    version='0.0.18',
     description='Command line tool for convenient access to '
     'Coursera Research Data Exports.',
     long_description=readme(),

--- a/tests/models/export_request_tests.py
+++ b/tests/models/export_request_tests.py
@@ -125,4 +125,4 @@ def test_export_request_with_metadata_deserialize_from_json():
     export_request = ExportRequestWithMetadata.from_json(export_request_json)
 
     assert export_request == ExportRequestWithMetadata(
-                                course_id=fake_course_id, id=fake_export_id)
+        course_id=fake_course_id, id=fake_export_id)


### PR DESCRIPTION
More informative error message in the case no clickstream export download links are available.

See #40 