### PR TITLE
Use partners API when inferring id from short name

### DIFF
--- a/courseraresearchexports/models/utils.py
+++ b/courseraresearchexports/models/utils.py
@@ -81,7 +81,7 @@ def lookup_partner_id_by_short_name(partner_short_name):
     Find the partner_id by short name
     """
     payload = {'q': 'shortName', 'shortName': partner_short_name}
-    return requests.get(COURSE_API, params=payload)
+    return requests.get(PARTNER_API, params=payload)
 
 
 @requests_response_to_model(

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 setup(
     name='courseraresearchexports',
-    version='0.0.19',
+    version='0.0.20',
     description='Command line tool for convenient access to '
     'Coursera Research Data Exports.',
     long_description=readme(),


### PR DESCRIPTION
This should finally fix the id inference from partner short name...  tested locally.