### PR TITLE
Cast partner_id as int since API returns string

### DIFF
--- a/courseraresearchexports/models/ExportRequest.py
+++ b/courseraresearchexports/models/ExportRequest.py
@@ -29,7 +29,7 @@ class ExportRequest:
                  statement_of_purpose=None, schema_names=None,
                  interval=None, ignore_existing=None, **kwargs):
         self._course_id = course_id
-        self._partner_id = partner_id
+        self._partner_id = int(partner_id) if partner_id is not None else partner_id
         self._group_id = group_id
         self._export_type = export_type
         self._anonymity_level = anonymity_level

--- a/courseraresearchexports/models/utils.py
+++ b/courseraresearchexports/models/utils.py
@@ -75,7 +75,7 @@ def lookup_course_id_by_slug(course_slug):
 
 
 @requests_response_to_model(
-    lambda response: response.json()['elements'][0]['id'])
+    lambda response: int(response.json()['elements'][0]['id']))
 def lookup_partner_id_by_short_name(partner_short_name):
     """
     Find the partner_id by short name

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 setup(
     name='courseraresearchexports',
-    version='0.0.20',
+    version='0.0.21',
     description='Command line tool for convenient access to '
     'Coursera Research Data Exports.',
     long_description=readme(),

--- a/tests/models/export_request_tests.py
+++ b/tests/models/export_request_tests.py
@@ -20,10 +20,12 @@ from courseraresearchexports.models.ExportRequest import ExportRequest
 from courseraresearchexports.models.ExportRequestWithMetadata import \
     ExportRequestWithMetadata
 from mock import patch
+from nose.tools import raises
 
 fake_course_id = 'fake_course_id'
 fake_course_slug = 'fake_course'
-fake_partner_id = 'fake_partner_id'
+fake_partner_id = 1
+bad_partner_id = 'bad_partner_id'
 fake_partner_short_name = 'fake_partner'
 fake_export_id = '1'
 
@@ -54,6 +56,9 @@ def test_create_from_args():
     export_request = ExportRequest.from_args(course_id=fake_course_id)
     assert ExportRequest(course_id=fake_course_id) == export_request
 
+@raises(ValueError)
+def test_create_from_args_non_integer_partner_id():
+    export_request = ExportRequest.from_args(partner_id=bad_partner_id)
 
 @patch('courseraresearchexports.models.utils.lookup_course_id_by_slug')
 def test_course_id_inference(lookup_course_id_by_slug):

--- a/tests/utils/utils_tests.py
+++ b/tests/utils/utils_tests.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+# Copyright 2016 Coursera
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from courseraresearchexports.models import utils
+from mock import Mock
+from mock import patch
+import requests
+
+fake_partner_short_name = 'fake_partner_short_name'
+fake_partner_id = 1
+fake_partner_response = {'elements': [ {"id": str(fake_partner_id)} ] }
+
+@patch.object(requests, 'get')
+def test_partner_id_lookup(mockget):
+    mock_partners_get_response = Mock()
+    mock_partners_get_response.json.return_value = fake_partner_response
+    mockget.return_value = mock_partners_get_response
+    inferred_partner_id = utils.lookup_partner_id_by_short_name(fake_partner_short_name)
+
+    assert inferred_partner_id == fake_partner_id


### PR DESCRIPTION
Confusingly, the partners API returns a string for partner_id when ExportRequest requires an int.