### PR TITLE
Add staff_graded_assignments to SCHEMA_NAMES

### DIFF
--- a/courseraresearchexports/constants/api_constants.py
+++ b/courseraresearchexports/constants/api_constants.py
@@ -35,6 +35,7 @@ SCHEMA_NAMES = [
     'assessments',
     'course_grades',
     'peer_assignments',
+    'staff_graded_assignments',
     'discussions',
     'programming_assignments',
     'course_content',


### PR DESCRIPTION
We added a new schema for Research Exports. Adding it to the list of schemas.